### PR TITLE
Build a wheel instead of an egg for dask-core.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,14 +10,15 @@ source:
   sha256: 07a0609ce053c8c2675037e6d5242899f90ecfb5262e1d0b2d7264fe8814099c
 
 build:
-  number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  number: 1
+  script: python setup.py bdist_wheel --universal;python -m wheel install --force dist/*.whl
   noarch: python
 
 requirements:
   build:
     - python
     - setuptools
+    - wheel
 
   run:
     - python


### PR DESCRIPTION
An egg is not exactly [python version resistant](https://packaging.python.org/discussions/wheel-vs-egg/). Look in the conda package:
```
$tar tf dask-core-0.16.1-py_0.tar.bz2 | grep 3\.6
site-packages/dask-0.16.1-py3.6.egg-info/not-zip-safe
site-packages/dask-0.16.1-py3.6.egg-info/dependency_links.txt
site-packages/dask-0.16.1-py3.6.egg-info/top_level.txt
site-packages/dask-0.16.1-py3.6.egg-info/requires.txt
site-packages/dask-0.16.1-py3.6.egg-info/PKG-INFO
site-packages/dask-0.16.1-py3.6.egg-info/SOURCES.txt
```

When other conda packages that have dask-core as a dependencies get built, they will try to bring in dask-core through the python setup.py stage and will fail in conda-build. Please consider using a wheel for the build choice of dask-core instead of an egg.

This one commit does that and the resulting package has no python version information:
```
$tar tf dask-core-0.16.1-py_1.tar.bz2 | grep 3\.6
$
```