### PR TITLE
Create dask and dask-core packages using a single recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   noarch: python
 
 requirements:
-  build:
+  host:
     - python >=3.6
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 214ffd3bb818827061deb5b3bc9bd425ee9d2fab6374d076acdd4c01e4b2f79f
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   noarch: python
 
@@ -25,6 +25,40 @@ requirements:
 test:
   imports:
     - dask
+
+outputs:
+  - name: dask-core
+
+  - name: dask
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.6
+      run:
+        - python >=3.6
+        - bokeh >=1.0.0
+        - cloudpickle >=0.2.1
+        - cytoolz >=0.7.3
+        - dask-core =={{ version }}
+        - distributed >={{ version }}
+        - fsspec >=0.6.0
+        - numpy >=1.13.0
+        - pandas >=0.21.0
+        - partd >=0.3.10
+        - toolz >=0.7.3
+    test:
+      imports:
+        - dask
+        - dask.array
+        - dask.bag
+        - dask.bytes
+        - dask.dataframe
+        - dask.dataframe.tseries
+        - dask.delayed
+        - dask.diagnostics
+        - dask.distributed
+        - distributed
 
 about:
   home: http://github.com/dask/dask/


### PR DESCRIPTION
Use a single meta.yaml to create both the `dask` and `dask-core` packages by using an outputs section.

Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
