### PR TITLE
Add new `dask` entrypoint

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,11 @@ source:
   sha256: f277a3b300ecc1d0be232a339f346dff686e0becdb0843c0aaf2ae943d5492d3
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
+  entry_points:
+    - dask = dask.cli:cli
 
 requirements:
   host:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Note I'm intentionally not adding any tests for this as the `dask` CLI requires `click` to be installed (which isn't a `dask-core` dependency). We're adding this entrypoint here so other package that depend on `dask-core`, and have `click` installed, like `distributed` and `dask`, will have the needed entrypoint included. 

Edit: This entrypoint is being moved from `dask` to here (`dask-core`) (xref https://github.com/conda-forge/distributed-feedstock/pull/226#issuecomment-1286023807,  https://github.com/conda-forge/dask-feedstock/pull/199) 