### PR TITLE
Add optional, constrained dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - pip
     - versioneer =0.28
     - tomli
-
   run:
     - python >=3.9
     - click >=8.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,13 @@ requirements:
     - pyyaml >=5.3.1
     - toolz >=0.10.0
     - importlib_metadata >=4.13.0
+  run_constrained:
+    - numpy >=1.21
+    - pandas >=1.3
+    - bokeh >=2.4.2
+    - jinja2 >=2.10.3
+    - pyarrow >=7.0
+    - lz4 >=4.3.2
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 980741966ef4d14c62dfb146f315f57d5eaaa6bedc52866f99687bc6054c2d4b
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:


### PR DESCRIPTION
If users want to install `dask-core` with `numpy` (or similar), make sure that the `numpy` version they install matches the version constraints Dask would add to these constraints.

xref: https://github.com/dask/dask/blob/499f4055da707fa76d06a2b79f408f124eee4723/pyproject.toml#L48-L77

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
